### PR TITLE
Added method to load Excel workbooks from a resource

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
                    (clojure.edn/read-string (slurp "order.edn"))
                    '[spork.cljgui.components.PaintPanel])))
 
-(defproject spork "0.2.1.4-SNAPSHOT"
+(defproject spork "0.2.1.5-SNAPSHOT"
   :description
   "A set of libraries derived from Spoon's Operations Research Kit.
    Libraries are modular and will be supported as stand-alone dependencies.
@@ -37,7 +37,9 @@
                  [org.clojure/core.rrb-vector  "0.1.1"]
                  ;;serialization lib.
                  [com.taoensso/nippy "2.11.0-RC1"]
-                 [ctries.clj "0.0.3"]]
+                 [ctries.clj "0.0.3"]
+                 [dk.ative/docjure "1.16.0"]
+                 ]
   :aot [spork.cljgui.components.PaintPanel]
   :profiles {:publish [:uberjar
                        {:aot [;spork.cljgui.components.PaintPanel

--- a/src/spork/util/excel/core.clj
+++ b/src/spork/util/excel/core.clj
@@ -11,7 +11,8 @@
                         [vector :as v]
                         [io :as io]
                         [string :as s]]
-            [clojure.string :refer [lower-case]])
+            [clojure.string :refer [lower-case]]
+            [dk.ative.docjure.spreadsheet :as dj])
   (:import [org.apache.poi.ss.usermodel Sheet Cell Row DataFormatter]))
 
 ;;we want to enable the ability for tables that have
@@ -364,6 +365,10 @@
 (defmethod as-workbook java.lang.String [wb] (load-workbook wb))
 (defmethod as-workbook org.apache.poi.xssf.usermodel.XSSFWorkbook [wb]
   wb)
+;;Probably a resource
+(defmethod as-workbook java.net.URL [^java.net.URL wb]
+  (with-open [stream (.openStream wb)]
+    (dj/load-workbook-from-stream stream)))
 
 (defmethod as-workbook :default [wb] 
   (throw (Exception. (str "Method not implemented for type " (type wb)))))


### PR DESCRIPTION
I added a small Excel m4 workbook to the resources in the m4 repo, and this enabled me to load up the test data and run the forward stationing tests from that workbook within the capsule.

Also version bumped so will push to Clojars if this pr gets approved.

Added dependency on docjure for some code in the taa repo where I have a temporary hack inside of the spork namespace for the code to read Excel workbooks.  There were performance updates to docjure code in spork.util.excel.docjure so haven't fully transitioned to new docjure  for spork.util.excel.docjure yet.