### PR TITLE
Allow duplicate separators at beginning of path

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
                    (clojure.edn/read-string (slurp "order.edn"))
                    '[spork.cljgui.components.PaintPanel])))
 
-(defproject spork "0.2.1.6-SNAPSHOT"
+(defproject spork "0.2.1.7-SNAPSHOT"
   :description
   "A set of libraries derived from Spoon's Operations Research Kit.
    Libraries are modular and will be supported as stand-alone dependencies.

--- a/src/spork/util/io.clj
+++ b/src/spork/util/io.clj
@@ -510,10 +510,23 @@
   [path]
   (io/file (file-path path)))
 
-(defn dedupe-separators [s]
+(defn replace-dupes
+  "Remove duplicate separators to allow concatenating of paths like
+  /blah/ and /blah2/ to /blah/blah2/ instead of /blah//blah2/."
+  [s]
   (strlib/replace s re-dupe (case +separator+
                               "\\" "\\\\"
                               +separator+)))
+
+(defn dedupe-separators
+  "We allow \\\\ at the beginning to use drive names in lieu of drive
+  letters on Windows."
+  [s]
+  (if (and (= (subs s 0 2) "\\\\")
+           ;;on Windows?
+           (= +separator+ "\\"))    
+    (str "\\\\" (replace-dupes (subs s 2)))
+    (replace-dupes s)))
 
 ;;we want to coerce a path like
 ;;~/blah/some-file -> home-path/blah/some/file

--- a/src/spork/util/io.clj
+++ b/src/spork/util/io.clj
@@ -519,14 +519,12 @@
                               +separator+)))
 
 (defn dedupe-separators
-  "We allow \\\\ at the beginning to use drive names in lieu of drive
-  letters on Windows."
+  "We allow two separators at the beginning of paths."
   [s]
-  (if (and (= (subs s 0 2) "\\\\")
-           ;;on Windows?
-           (= +separator+ "\\"))    
-    (str "\\\\" (replace-dupes (subs s 2)))
-    (replace-dupes s)))
+  (let [two-seps (str +separator+ +separator+)]
+    (if (= (subs s 0 2) two-seps)    
+      (str two-seps (replace-dupes (subs s 2)))
+      (replace-dupes s))))
 
 ;;we want to coerce a path like
 ;;~/blah/some-file -> home-path/blah/some/file


### PR DESCRIPTION
on Windows.  Version bump to bundle with m4.

Addresses Jan issue and our chat from Jan 24.  Will allow me to remove my monkey patch.